### PR TITLE
Fixed view to show 100% progress

### DIFF
--- a/DAProgressOverlayView/DAProgressOverlayView.m
+++ b/DAProgressOverlayView/DAProgressOverlayView.m
@@ -141,7 +141,7 @@ CGFloat const DAUpdateUIFrequency = 1. / 25.;
 {
     if (_progress != progress) {
         _progress = (progress < 0.) ? 0. : (progress > 1.) ? 1. : progress;
-        if (progress > 0. && progress < 1.) {
+        if (progress > 0. && progress <= 1.) {
             self.state = DAProgressOverlayViewStateOperationInProgress;
             [self setNeedsDisplay];
         } else if (progress == 1. && self.triggersDownloadDidFinishAnimationAutomatically) {


### PR DESCRIPTION
The progress view should still be able to show 100%, in my case I have didFinishAnimationAutomatically set to NO
