### PR TITLE
Fixes issue where setting progress to 0 is ignored.

### DIFF
--- a/DAProgressOverlayView/DAProgressOverlayView.m
+++ b/DAProgressOverlayView/DAProgressOverlayView.m
@@ -146,7 +146,10 @@ CGFloat const DAUpdateUIFrequency = 1. / 25.;
             [self setNeedsDisplay];
         } else if (progress == 1. && self.triggersDownloadDidFinishAnimationAutomatically) {
             [self displayOperationDidFinishAnimation];
-        }        
+        } else {
+            self.state = DAProgressOverlayViewStateWaiting;
+            [self setNeedsDisplay];
+        }
     }
 }
 


### PR DESCRIPTION
I use this in a tableview cell where it is recycled and because 0 is ignored the last cell's progress is displayed because setting progress to 0 did not kick off a redraw. This commit fixes the issue.
